### PR TITLE
chore: update to manon v18.4.0 and fix vite 8 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
        esac \
     && curl -fsSL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$NODE_ARCH.tar.xz" \
        | tar -xJ -C /usr/local --strip-components=1 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install uv
 ADD https://astral.sh/uv/$UV_VERSION/install.sh /uv-installer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ ENV NODE_VERSION=22.20.0
 WORKDIR /app
 
 # Install Node.js
-RUN apt-get update && apt-get install -y curl xz-utils \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    xz-utils \
     && ARCH=$(dpkg --print-architecture) \
     && case "$ARCH" in \
          amd64) NODE_ARCH="x64";; \
@@ -16,7 +18,7 @@ RUN apt-get update && apt-get install -y curl xz-utils \
        esac \
     && curl -fsSL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$NODE_ARCH.tar.xz" \
        | tar -xJ -C /usr/local --strip-components=1 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install uv
 ADD https://astral.sh/uv/$UV_VERSION/install.sh /uv-installer.sh

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -31,9 +31,9 @@ extensions = [
 
 If you're using any of the image-related options listed on
 [Customization](customization.md) (`logo`) or a
-[custom stylesheet](customization.md#custom-stylesheet), you'll also want to
-tell Sphinx where to get these files from. Add a line like this to your
-`conf.py` (changing the path if necessary):
+[custom stylesheet](customization.md), you'll also want to tell Sphinx where to
+get these files from. Add a line like this to your `conf.py` (changing the path
+if necessary):
 
 ```python
 html_static_path = ["_static"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+npm ci
+
 # Run vite build --watch in the background to rebuild assets on change
 npm run dev &
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+set -e
+
+# Run vite build --watch in the background to rebuild assets on change
+npm run dev &
 
 # Start sphinx-autobuild in the foreground
-uv run sphinx-autobuild docs/source docs/build/html --host 0.0.0.0 --port 8000 --watch src/
+uv run sphinx-autobuild docs/source docs/build/html -E --host 0.0.0.0 --port 8000 --watch src/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "name": "@minvws/manon-rijkshuisstijl-2008-sphinx-theme",
       "license": "UNLICENSED",
       "dependencies": {
-        "@minvws/manon": "^18.3.0",
-        "@minvws/manon-themes": "^18.3.0"
+        "@minvws/manon": "^18.4.0",
+        "@minvws/manon-themes": "^18.4.0"
       },
       "devDependencies": {
         "sass": "~1.98.0",
@@ -54,21 +54,21 @@
       }
     },
     "node_modules/@minvws/manon": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@minvws/manon/-/manon-18.3.0.tgz",
-      "integrity": "sha512-uPTii6jmfaX5rzzxkId19QO7YCjHTf3AMJs66C6zuu5AnA3ZhSt08KOtjwnkNGwPcqzlmNJi91wYfg8ZIem4Og==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@minvws/manon/-/manon-18.4.0.tgz",
+      "integrity": "sha512-Q/iD84XFmpz1zQoBlwPXNHmiqv3DaxdP3VJG/JGJejVXJcVeDKimsRcvVGVJ0yyB47dmY2ZP4nV9sTlO+TiFCQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "sass": ">=1.77.6"
       }
     },
     "node_modules/@minvws/manon-themes": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@minvws/manon-themes/-/manon-themes-18.3.0.tgz",
-      "integrity": "sha512-w5t/wX2elJlEWv8g70cgZSm8z8y4e99RBbGDGRKJui44eCH1gTcppr6gLrOFYWjm7TQo40dvWBa4NfgZZP+Uyg==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@minvws/manon-themes/-/manon-themes-18.4.0.tgz",
+      "integrity": "sha512-PAucHqu6ZWePdPP3upNrcM7AVjQXgSbeg03ywpegDL0XA9NkEg3DqZfubyBipi03fOpPsin5EDXHAvk7HRz0PQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
-        "@minvws/manon": "18.3.0"
+        "@minvws/manon": "18.4.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "dev": "vite build --watch"
   },
   "dependencies": {
-    "@minvws/manon": "^18.3.0",
-    "@minvws/manon-themes": "^18.3.0"
+    "@minvws/manon": "^18.4.0",
+    "@minvws/manon-themes": "^18.4.0"
   },
   "devDependencies": {
     "sass": "~1.98.0",

--- a/src/sphinx_rijkshuisstijl_2008/theme/sphinx_rijkshuisstijl_2008/theme.conf
+++ b/src/sphinx_rijkshuisstijl_2008/theme/sphinx_rijkshuisstijl_2008/theme.conf
@@ -1,7 +1,7 @@
 [theme]
 name = sphinx_rijkshuisstijl_2008
 inherit = alabaster
-stylesheet = css/theme.css
+stylesheet = assets/style.css
 
 [theme.pygments_style]
 default = default

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,3 +1,6 @@
+// Import the main SCSS file which includes all necessary styles from @minvws/mano
+import "../scss/index.scss";
+
 // Import all necessary JS modules from @minvws/manon
 import "@minvws/manon/js/accordion.js";
 import "@minvws/manon/js/collapsible.js";

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,4 +1,4 @@
-// Import the main SCSS file which includes all necessary styles from @minvws/mano
+// Import the main SCSS file which includes all necessary styles from @minvws/manon
 import "../scss/index.scss";
 
 // Import all necessary JS modules from @minvws/manon

--- a/static/scss/index.scss
+++ b/static/scss/index.scss
@@ -1,6 +1,6 @@
 @use "@minvws/manon-themes/rijkshuisstijl-2008" with (
-  $font-path: "/_static/fonts",
-  $icons-path: "/_static/img/icons"
+  $font-path: "@manon-themes/fonts",
+  $icons-path: "@manon-themes/img/icons"
 );
 
 @use "@minvws/manon/components/bundles/all";

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,70 +2,62 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 
+// Output directory for the built assets, matching Sphinx's expected structure
 const OUT_DIR = resolve(
   __dirname,
   "src/sphinx_rijkshuisstijl_2008/theme/sphinx_rijkshuisstijl_2008/static",
 );
 
 export default defineConfig({
+  // Set base to relative path for correct asset loading in Sphinx
+  base: "./",
+
+  // Alias to simplify imports from @minvws/manon-themes
+  resolve: {
+    alias: {
+      "@manon-themes": resolve(
+        __dirname,
+        "node_modules/@minvws/manon-themes/dist/rijkshuisstijl-2008",
+      ),
+    },
+  },
+
+  // Build configuration
   build: {
     outDir: OUT_DIR,
     emptyOutDir: true,
     cssCodeSplit: false,
 
-    rollupOptions: {
+    rolldownOptions: {
       input: {
         theme: resolve(__dirname, "static/js/main.js"),
-        styles: resolve(__dirname, "static/scss/index.scss"),
       },
-
       output: {
         entryFileNames: "js/[name].js",
-
-        assetFileNames: (assetInfo) => {
-          const name = assetInfo.name ?? "";
-
-          // Force single known CSS output
-          if (name.endsWith(".css")) {
-            return "css/theme.css";
-          }
-
-          // Fonts
-          if (/\.(woff2?|ttf|eot|otf)$/.test(name)) {
-            return "fonts/[name][extname]";
-          }
-
-          // Images
-          if (/\.(png|jpe?g|svg|gif|webp|ico)$/.test(name)) {
-            return "img/[name][extname]";
-          }
-
-          // Everything else (hash-safe)
-          return "assets/[name].[hash][extname]";
-        },
+        assetFileNames: "assets/[name][extname]",
       },
     },
   },
 
+  // Copy static assets from both the theme and the Manon themes
   plugins: [
     viteStaticCopy({
       targets: [
         {
           src: "static/img/**/*.{png,jpg,jpeg,svg,gif,webp,ico}",
           dest: "img",
+          rename: { stripBase: 2 },
         },
         {
-          src: "node_modules/@minvws/manon-themes/dist/rijkshuisstijl-2008/fonts/*",
-          dest: "fonts",
-        },
-        {
-          src: "node_modules/@minvws/manon-themes/dist/rijkshuisstijl-2008/img/*",
+          src: "node_modules/@minvws/manon-themes/dist/rijkshuisstijl-2008/img/**/*",
           dest: "img",
+          rename: { stripBase: 6 },
         },
       ],
     }),
   ],
 
+  // SCSS configuration to include node_modules for Manon themes
   css: {
     preprocessorOptions: {
       scss: {


### PR DESCRIPTION
## Changes

This PR updates Manon to version v18.4.0 as well address a build failure introduced with Vite 8's new Rolldown bundler.

- Moved scss import (`index.scss`) directly into the main javascript entrypoint (`main.js`). This ensures the bundler correctly traces the full dependency graph.
- Added `@manon-themes` alias in the `vite.config.js` pointing to the distribution folder in `node_modules`.
- Refactored assets bundling to be compatible with Rolldown
- Updated correct assets references in sphinx configuration
- Generated css should use relative paths instead of root-relative ones (https://github.com/minvws/manon-rijkshuisstijl-2008-sphinx-theme/issues/32)