### PR TITLE
fix: search functionality

### DIFF
--- a/src/sphinx_rijkshuisstijl_2008/theme/sphinx_rijkshuisstijl_2008/layout.html
+++ b/src/sphinx_rijkshuisstijl_2008/theme/sphinx_rijkshuisstijl_2008/layout.html
@@ -106,7 +106,9 @@
       <article>
         {% block document %}
           <div class="content-wrapper">
-            {{ body }}
+            {% block body %}
+              {{ body }}
+            {% endblock %}
           </div>
         {% endblock %}
 


### PR DESCRIPTION
## Changes

- `search.html` wasn't able to override the `body` block in the `layout.html` template. `{{ body }}` is now wrapped in a `{% block body %}` block within `layout.html`, which allow normal pages to still default to standard document bodies, while allowing templates like `search.html` to inject their custom markup.

## Test / Review

1. Build the container

```console
docker build -t sphinx-rijkshuisstijl-2008 .
```

2. Run the container

```console
docker run -p 8000:8000 -it --rm -v $(pwd):/app -v /app/node_modules sphinx-rijkshuisstijl-2008
```

3. Verify

   1. Open your browser and navigate to the search page: http://localhost:8000/search.html.
   2. Confirm that the "Search" heading, descriptive paragraphs, and search results container are now visible.
   3. Type a query in the search bar and verify that search results populate dynamically as expected.
   
## Fixes

Fixes #72 
